### PR TITLE
Rebuild 0.14.0: recover missing osx-arm64 mpich package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libmbd" %}
 {% set version = "0.14.0" %}
-{% set build = 0 %}
+{% set build = 1 %}
 {% set mpi = mpi or "nompi" %}
 
 package:


### PR DESCRIPTION
Bumps the build number from 0 to 1 to rebuild and upload the **osx-arm64 `mpi_mpich`** package, which is missing from the 0.14.0 release.

### Why
The `osx_arm64_mpimpich` job failed on the post-merge `main` build (Azure buildId 1531111) with a transient conda-build error while the other five osx jobs succeeded and uploaded:

```
File ".../conda_build/render.py", line 421, in execute_download_actions
IndexError: list index out of range
```

As a result, conda-forge has osx-arm64 `nompi` and `mpi_openmpi` for 0.14.0 but no `mpi_mpich`. Every other platform has all three variants. This is the same flaky `get_upstream_pins`/`execute_download_actions` error that also hit the original version-bump PR (#37).

### Fix
No recipe/dependency changes — just a build-number bump so CI rebuilds the full matrix and re-uploads, restoring the missing osx-arm64 mpich build.

Checklist:
- [ ] osx_arm64_mpimpich builds and uploads green (rerun if the same flake recurs)